### PR TITLE
Creates a local config file unless it already exists every time Vagrant starts

### DIFF
--- a/lib/bib/bib_vagrant_npm_provisioner.rb
+++ b/lib/bib/bib_vagrant_npm_provisioner.rb
@@ -18,6 +18,12 @@ end
 class BibConfigurePlugin < Vagrant.plugin('2')
   name 'NPM configuration Provisioner'
 
+  # Create a local config, unless it already exists
+  action_hook(:environment_load) do |hook|
+    config = Bib::Vagrant::Config.new
+    config.get # Creates the config file unless existing already and the gets it
+  end
+
   # This plugin provides a provisioner called unix_reboot.
   provisioner 'bib_configure_npm' do
     # Create a provisioner.


### PR DESCRIPTION
This creates a local Vagrant config file unless one already exists. #5384