### PR TITLE
Fix shared folder missing error

### DIFF
--- a/bib-vagrant.gemspec
+++ b/bib-vagrant.gemspec
@@ -6,7 +6,7 @@ require 'bib/version'
 Gem::Specification.new do |spec|
   spec.name          = 'bib-vagrant'
   spec.version       = Bib::Vagrant::VERSION
-  spec.authors       = %w('tillk', 'fh', 'gilleyj')
+  spec.authors       = %w(tillk, fh, gilleyj, seppsepp)
   spec.email         = ['till@php.net']
   spec.description   = "A rubygem to centralize configuration and setup in every project's Vagrantfile"
   spec.summary       = 'Centralize configuration and setup'

--- a/lib/bib/bib_vagrant.rb
+++ b/lib/bib/bib_vagrant.rb
@@ -130,7 +130,7 @@ module Bib
         dna = add_composertoken_to_dna(dna, vagrantconfig)
         dna['vagrant'][applicationlist].each do |app, app_config|
           vagrant_share = File.expand_path(app_config['app_root_location'])
-          host_folder = "#{File.dirname(__FILE__)}/sites/#{app}"
+          host_folder = "#{vagrantconfig['cookbook_path']}/#{app}"
           if vagrantconfig['nfs']
             machine.vm.synced_folder host_folder, vagrant_share, type: 'nfs', mount_options: ['nolock,vers=3,udp,noatime,actimeo=1']
           elsif vagrantconfig['rsync']

--- a/lib/bib/bib_vagrant.rb
+++ b/lib/bib/bib_vagrant.rb
@@ -126,11 +126,11 @@ module Bib
         dna
       end
 
-      def prepare_app_settings(vagrantconfig, machine, dna, host_folder, applicationlist = 'applications')
+      def prepare_app_settings(vagrantconfig, machine, dna, host_folder_root, applicationlist = 'applications')
         dna = add_composertoken_to_dna(dna, vagrantconfig)
         dna['vagrant'][applicationlist].each do |app, app_config|
           vagrant_share = File.expand_path(app_config['app_root_location'])
-          host_folder += "/#{app}"
+          host_folder = host_folder_root + "/#{app}"
           if vagrantconfig['nfs']
             machine.vm.synced_folder host_folder, vagrant_share, type: 'nfs', mount_options: ['nolock,vers=3,udp,noatime,actimeo=1']
           elsif vagrantconfig['rsync']

--- a/lib/bib/bib_vagrant.rb
+++ b/lib/bib/bib_vagrant.rb
@@ -126,11 +126,11 @@ module Bib
         dna
       end
 
-      def prepare_app_settings(vagrantconfig, machine, dna, applicationlist = 'applications')
+      def prepare_app_settings(vagrantconfig, machine, dna, host_folder, applicationlist = 'applications')
         dna = add_composertoken_to_dna(dna, vagrantconfig)
         dna['vagrant'][applicationlist].each do |app, app_config|
           vagrant_share = File.expand_path(app_config['app_root_location'])
-          host_folder = "#{vagrantconfig['cookbook_path']}/#{app}"
+          host_folder += "/#{app}"
           if vagrantconfig['nfs']
             machine.vm.synced_folder host_folder, vagrant_share, type: 'nfs', mount_options: ['nolock,vers=3,udp,noatime,actimeo=1']
           elsif vagrantconfig['rsync']

--- a/lib/bib/version.rb
+++ b/lib/bib/version.rb
@@ -1,5 +1,5 @@
 module Bib
   module Vagrant
-    VERSION = '0.1.3'
+    VERSION = '0.1.4'
   end
 end

--- a/lib/bib/version.rb
+++ b/lib/bib/version.rb
@@ -1,5 +1,5 @@
 module Bib
   module Vagrant
-    VERSION = '0.1.4'
+    VERSION = '0.1.5'
   end
 end


### PR DESCRIPTION
The issue caused output like this:

  There are errors in the configuration of this machine. Please fix
  the following errors and try again:

  vm:
  * The host path of the shared folder is missing: ~/Sites/easybib/cookbooks/scholar-admin

...because wrong path was used. Now path from config is used.