### PR TITLE
[WIP] Bump to vagrant-1.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.0.0
+  - 2.2.3
 
 script:
   - bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in bib-vagrant.gemspec
 # (no idea how to get the github-reference below in .gemspec)
-# gemspec
 
 group :development do
   gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: "v1.9.1"
@@ -11,5 +10,5 @@ group :development do
 end
 
 group :plugins do
-  gem 'bib-vagrant', path: '.'
+    gemspec
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in bib-vagrant.gemspec
 # (no idea how to get the github-reference below in .gemspec)
-gemspec
+# gemspec
 
 group :development do
   gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: "v1.9.1"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git'
+  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: "v1.9.1"
   # gem "vagrant", git: "git://github.com/mitchellh/vagrant.git", tag: "v1.7.4"
   # gem "vagrant", git: "git://github.com/mitchellh/vagrant.git", tag: "v1.3.5"
 end

--- a/bib-vagrant.gemspec
+++ b/bib-vagrant.gemspec
@@ -6,7 +6,7 @@ require 'bib/version'
 Gem::Specification.new do |spec|
   spec.name          = 'bib-vagrant'
   spec.version       = Bib::Vagrant::VERSION
-  spec.authors       = %w(tillk fh gilleyj seppsepp)
+  spec.authors       = %w(tillk fh gilleyj seppsepp baccenfutter)
   spec.email         = ['till@php.net']
   spec.description   = "A rubygem to centralize configuration and setup in every project's Vagrantfile"
   spec.summary       = 'Centralize configuration and setup'
@@ -18,9 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'thor', '>= 0.18.1'
+
+  spec.add_dependency 'thor', '>= 0.19.4'
   spec.add_dependency 'colored', '>= 1.2'
-  spec.add_dependency 'rest_client'
+  spec.add_dependency 'rest-client', '>= 1.6.0', '< 3.0'
   spec.add_dependency 'json'
 
   spec.add_development_dependency 'bundler', '~> 1.5'

--- a/lib/bib/version.rb
+++ b/lib/bib/version.rb
@@ -1,5 +1,5 @@
 module Bib
   module Vagrant
-    VERSION = '0.1.6'
+    VERSION = '0.1.7'
   end
 end

--- a/lib/bib/version.rb
+++ b/lib/bib/version.rb
@@ -1,5 +1,5 @@
 module Bib
   module Vagrant
-    VERSION = '0.1.7'
+    VERSION = '0.1.8'
   end
 end


### PR DESCRIPTION
This PR bumps `bib-vagrant` to `0.1.7` in order to support latest `vagrant-1.9.1`.

https://github.com/easybib/ops/issues/249